### PR TITLE
.travis.yml for Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
   - "iojs"
-  - "7"
+  - "8"


### PR DESCRIPTION
- Added .travis.yml for Travis CI integration

As our Standard JS version requires to be run on Node JS version 8 or later, the file content is as follows for now. 

~~~
language: node_js
node_js:
  - "iojs"
  - "8"
~~~